### PR TITLE
Fix Catagory form and add enter-to-cart on cashier page

### DIFF
--- a/idealmarket/market/forms.py
+++ b/idealmarket/market/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import Product, Ombor
+from .models import Product, Ombor, Catagory
 
 from django.utils import timezone
 from datetime import timedelta
@@ -19,3 +19,12 @@ class OmborForm(forms.ModelForm):
     class Meta:
         model = Ombor
         fields = ['name']
+
+class CatagoryForm(forms.ModelForm):
+    class Meta:
+        model = Catagory
+        fields = ['name', 'desc']
+        widgets = {
+            'name': forms.TextInput(attrs={'class': 'form-control'}),
+            'desc': forms.Textarea(attrs={'class': 'form-control', 'rows': 2}),
+        }

--- a/idealmarket/market/templates/market/kassa.html
+++ b/idealmarket/market/templates/market/kassa.html
@@ -51,6 +51,26 @@ $(function(){
         });
     });
 
+    $('#search-input').on('keydown', function(e){
+        if(e.key === 'Enter'){
+            e.preventDefault();
+            var query = $(this).val();
+            $.ajax({
+                url: "{% url 'kassa' %}",
+                data: {q: query},
+                headers: {'X-Requested-With': 'XMLHttpRequest'},
+                success: function(data){
+                    $('#products-table').html(data.products_html);
+                    var $first = $('.cart-add-form').first();
+                    if($first.length){
+                        $first.find('input[name="quantity"]').val(1);
+                        $first.submit();
+                    }
+                }
+            });
+        }
+    });
+
     $(document).on('submit', '.cart-add-form, .cart-remove-form, #cart-clear-form, #cart-checkout-form, .update-cart', function(e){
         e.preventDefault();
         var $form = $(this);

--- a/idealmarket/market/views.py
+++ b/idealmarket/market/views.py
@@ -12,7 +12,7 @@ from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
 
 from django import forms
-from .forms import ProductForm, OmborForm
+from .forms import ProductForm, OmborForm, CatagoryForm
 import pandas as pd
 from django.db.models.functions import ExtractHour
 


### PR DESCRIPTION
## Summary
- create `CatagoryForm` model form
- import the new form in views
- add keyboard handler in `kassa.html` so pressing Enter adds the first found product to cart

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684bb911b7608323a2abd7c279f76ba7